### PR TITLE
fix-pageload-scroll

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -73,6 +73,7 @@
   <script src="//cdn.jsdelivr.net/npm/docsify/lib/plugins/zoom-image.min.js"></script>
   <script src="//cdn.jsdelivr.net/npm/docsify-tabs@1"></script>
   <script src="//cdn.jsdelivr.net/npm/docsify-copy-code/dist/docsify-copy-code.min.js"></script>
+  <script src="./script/docsify-fix-pageload-scroll.js"></script>
   <script src="//polyfill.io/v3/polyfill.min.js?features=String.prototype.normalize"></script>
 </body>
 

--- a/docs/script/docsify-fix-pageload-scroll.js
+++ b/docs/script/docsify-fix-pageload-scroll.js
@@ -1,0 +1,20 @@
+// docsify-fix-pageload-scroll.js
+(function () {
+  function create() {
+      return (hook) => {
+          const TARGET_QUERY = 'id';
+          const SCROLL_DELAY = 500;
+
+          hook.doneEach(function () {
+              if (!location.hash.includes('?')) return;
+              let searchParams = new URLSearchParams(location.hash.split('?')[1]);
+              let header = document.querySelector('#' + searchParams.get(TARGET_QUERY));
+              header && setTimeout(() => header.scrollIntoView(), SCROLL_DELAY);
+          });
+      };
+  }
+
+  if (typeof $docsify === 'object') {
+      $docsify.plugins = [].concat(create(), $docsify.plugins);
+  }
+})();


### PR DESCRIPTION
Fix for [Direct link to sub-item not scrolling to correct position](https://github.com/docsifyjs/docsify/issues/351#issuecomment-748058489)